### PR TITLE
Fix windows makefile

### DIFF
--- a/Makefile_windows
+++ b/Makefile_windows
@@ -38,6 +38,7 @@ EXTRASRCS = \
 	$(SDIR)/stm8s_tim3.c \
 	$(SDIR)/stm8s_exti.c \
 	$(SDIR)/stm8s_adc1.c \
+	$(SDIR)/stm8s_flash.c \
 	watchdog.c \
 	torque_sensor.c \
 	uart.c \

--- a/Start_Compiling.bat
+++ b/Start_Compiling.bat
@@ -4,7 +4,7 @@ del main.hex
 make -f Makefile_windows clean
 make -f Makefile_windows
 
-STVP_CmdLine -BoardName=ST-LINK -ProgMode=SWIM -Port=USB -Device=STM8S105x6 -FileProg=main.ihx -verbose -no_loop
+::STVP_CmdLine -BoardName=ST-LINK -ProgMode=SWIM -Port=USB -Device=STM8S105x6 -FileProg=main.ihx -verbose -no_loop
 
 pause
 exit

--- a/clean.bat
+++ b/clean.bat
@@ -1,13 +1,17 @@
+@ECHO OFF
+
 cd stdperiphlib\src
-del *.asm
-del *.rel
-del *.lk
-del *.lst
-del *.rst
-del *.sym
-del *.cdb
-del *.map
-del *.elf
-del *.bin
+del /q *.asm >NUL 2>NUL
+del /q *.rel >NUL 2>NUL
+del /q *.lk >NUL 2>NUL
+del /q *.lst >NUL 2>NUL
+del /q *.rst >NUL 2>NUL
+del /q *.sym >NUL 2>NUL
+del /q *.cdb >NUL 2>NUL
+del /q *.map >NUL 2>NUL
+del /q *.elf >NUL 2>NUL
+del /q *.bin >NUL 2>NUL
 cd..
 cd..
+
+@ECHO ON


### PR DESCRIPTION
Included missing source file in the Windows makefile. Improved clean up script for Windows. Disabled automatic commandline flash of firmware to controller, we can use STVP GUI for this.